### PR TITLE
Click-Handler deadlock beseitigt

### DIFF
--- a/GameOfLife/GameOfLife.cs
+++ b/GameOfLife/GameOfLife.cs
@@ -1,0 +1,55 @@
+﻿using Avalonia.Media;
+
+namespace GameOfLife;
+
+public static class GameOfLife {
+    public static bool[,] CalculateNextGeneration(bool[,] world) {
+        bool[,] newWorld = new bool[world.GetLength(0), world.GetLength(1)];
+        Array.Copy(world, newWorld, world.Length);
+
+        for (int i = 0; i < world.GetLength(0); i++) {
+            for (int j = 0; j < world.GetLength(1); j++) {
+                // if the cell is alive and doesn't have 2 or 3 neighbours, it dies
+                if (world[i, j] && CountNeighbours(world, i, j) is not 2 and not 3) newWorld[i, j] = false;
+
+                // if the cell is dead and has 3 neighbours, it lives
+                if (!world[i, j] && CountNeighbours(world, i, j) == 3) newWorld[i, j] = true;
+            }
+        }
+
+        return newWorld;
+    }
+
+    private static int CountNeighbours(bool[,] world, int row, int col) {
+        int[] rows = [row - 1, row, row + 1];
+        int[] cols = [col - 1, col, col + 1];
+            
+        return (from r in rows
+            from c in cols
+            where r != row || c != col
+            let currentRow = (r + world.GetLength(0)) % world.GetLength(0)
+            let currentCol = (c + world.GetLength(1)) % world.GetLength(1)
+            where world[currentRow, currentCol]
+            select 0).Count();
+    }
+
+    public static bool[,] GenerateRandomWorld(int length) {
+        bool[,] world = new bool[length, length];
+        for (int i = 0; i < length; i++) {
+            for (int j = 0; j < length; j++) {
+                // Random.Shared.Next is exclusive, so this will generate either 0 or 1
+                world[i, j] = Random.Shared.Next(0, 2) == 0;
+            }
+        }
+
+        return world;
+    }
+
+    public static void PrintWorld(bool[,] world, IImmutableSolidColorBrush color) {
+        for (int i = 0; i < world.GetLength(0); i++) {
+            for (int j = 0; j < world.GetLength(1); j++) {
+                LeoBoard.Board.SetCellContent(i, j, world[i, j] ? Program.CELL : " ", color);
+            }
+        }
+    }
+}

--- a/GameOfLife/GameOfLife.csproj
+++ b/GameOfLife/GameOfLife.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LeoBoard\LeoBoard.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/GameOfLife/Program.cs
+++ b/GameOfLife/Program.cs
@@ -1,0 +1,91 @@
+﻿using Avalonia.Media;
+
+namespace GameOfLife;
+
+using System;
+
+public static class Program {
+    private const int MAX_BOARD_SIZE = 80;
+    private const int SIZE = 20;
+    public const string CELL = "\u2588";
+    //public const string CELL = "*";
+    
+    private static readonly IImmutableSolidColorBrush DrawingColor = Brushes.White;
+    private static readonly IImmutableSolidColorBrush SimulationColor = Brushes.Blue;
+    
+    private static void Main() {
+        Console.WriteLine("Game of Life");
+        Console.WriteLine("============");
+        Console.WriteLine("If you input a negative size, a random world with the positive size will be generated");
+        int length;
+        do {
+            Console.Write($"Input size: [-{MAX_BOARD_SIZE}..{MAX_BOARD_SIZE}]: ");
+        } while (!int.TryParse(Console.ReadLine(), out length) || Math.Abs(length) > MAX_BOARD_SIZE);
+
+        if (length == 0) {
+            Console.WriteLine("Can't create a 0-length world");
+            return;
+        }
+
+        bool[,] world = length < 0 ? GameOfLife.GenerateRandomWorld(-length) : new bool[length, length];
+
+        bool canDraw = true;
+        length = Math.Abs(length);
+
+        Console.WriteLine("\nInitializing LeoBoard...\n");
+
+        /*
+         * Documentation of currently used tools
+         *  Start the Board with Board.Initialize(Main, optional)
+         *      Main: The board suspends the thread until it's closed again
+         *            The MainMethod parameter is the method that will be called while the board is open
+         *
+         *      Optional: Title: The Window Title
+         *                Rows/Columns: The numbers of rows/columns of the window
+         *                DrawGridNumbers: If the grid should be numbered
+         *                ClickHandler (x, y, isLeft, unknown):
+         *                  X/Y: The position where the click occured
+         *                  Flag1: True if the right mouse button is pressed, False otherwise
+         *                  Flag2: True if CTRL is pressed, False otherwise
+         *
+         *  Set a single cell in the Board with Board.SetCellContent(x, y, symbol, color)
+         *      X/Y: The Position of the content
+         *      Symbol: The symbol to write (only 1 char)
+         *      Color: The color of the text (usage: Brushes.Color)
+         *
+         *
+         *  Get the content of a single cell in the Board with Board.GetCellContent(x, y):
+         *      X/Y: The Position to get the contents from
+         *      Returns (string): The Character at the Position (X, Y)
+         */
+        LeoBoard.Board.Initialize(() => {
+                GameOfLife.PrintWorld(world, DrawingColor);
+                Console.WriteLine("Click on a point to toggle it");
+                Console.WriteLine("\nPress any key to start the simulation...");
+                Console.ReadKey(true);
+                
+                canDraw = false;
+
+                Console.Write("\nPress any key to close...");
+                while (!Console.KeyAvailable) {
+                    world = GameOfLife.CalculateNextGeneration(world);
+                    GameOfLife.PrintWorld(world, SimulationColor);
+                    Task.Delay(100).Wait();
+                }
+
+                Environment.Exit(0);
+            },
+            clickHandler: (x, y, isNotRightClick, controlPressed) => {
+                if (!canDraw) return;
+                
+                LeoBoard.Board.SetCellContent(x, y, world[x, y] ? " " : CELL, DrawingColor);
+                world[x, y] = !world[x, y];
+            },
+            title: "Game of Life",
+            rows: length,
+            columns: length,
+            cellSize: SIZE,
+            fontSize: SIZE
+        );
+    }
+}

--- a/LeoBoard.sln
+++ b/LeoBoard.sln
@@ -1,0 +1,36 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LeoBoardTest", "LeoBoardTest\LeoBoardTest.csproj", "{F1B79410-93AA-4AB2-AC48-1F8B4AD0CBD6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LeoBoard", "LeoBoard\LeoBoard.csproj", "{537E16FA-F98E-4D42-98C1-388B2A96611B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameOfLife", "GameOfLife\GameOfLife.csproj", "{D4D104A8-311B-4CB0-BF58-247B44770F9D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F1B79410-93AA-4AB2-AC48-1F8B4AD0CBD6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1B79410-93AA-4AB2-AC48-1F8B4AD0CBD6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1B79410-93AA-4AB2-AC48-1F8B4AD0CBD6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1B79410-93AA-4AB2-AC48-1F8B4AD0CBD6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{537E16FA-F98E-4D42-98C1-388B2A96611B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{537E16FA-F98E-4D42-98C1-388B2A96611B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{537E16FA-F98E-4D42-98C1-388B2A96611B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{537E16FA-F98E-4D42-98C1-388B2A96611B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4D104A8-311B-4CB0-BF58-247B44770F9D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4D104A8-311B-4CB0-BF58-247B44770F9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4D104A8-311B-4CB0-BF58-247B44770F9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4D104A8-311B-4CB0-BF58-247B44770F9D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+	EndGlobalSection
+EndGlobal

--- a/LeoBoardTest/LeoBoardTest.csproj
+++ b/LeoBoardTest/LeoBoardTest.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LeoBoard\LeoBoard.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/LeoBoardTest/Program.cs
+++ b/LeoBoardTest/Program.cs
@@ -1,0 +1,96 @@
+﻿// See https://aka.ms/new-console-template for more information
+
+using System;
+using System.Diagnostics;
+using System.Text;
+using Avalonia.Media;
+using LeoBoard;
+
+const int BOARD_SIZE = 60;
+
+Console.WriteLine("Hello, Leoboard!!");
+
+Board.Initialize(Points, "Foo", BOARD_SIZE, BOARD_SIZE, 
+    20, 
+    12, 
+    true, 
+    0,
+    clickHandler: HandleClick);
+
+return;
+
+void Run()
+{
+    Console.OutputEncoding = Encoding.UTF8;
+    
+    Board.SetCellContent(0, 0, "X");
+    Board.SetCellContent(1, 1, "Y", Brushes.Red);
+    Board.SetCellContent(2, 2, "Z", Brushes.Blue);
+    
+    Console.WriteLine(Board.GetCellContent(2, 2));
+    
+    Board.ShowMessageBox("Hello World!");
+    
+    Console.ReadKey();
+}
+
+void Points()
+{
+    var world = new bool[BOARD_SIZE, BOARD_SIZE];
+    for (int i = 0; i < world.GetLength(0); i++)
+    {
+        for(int j=0; j < world.GetLength(1); j++)
+        {
+            world[i, j] = Random.Shared.Next(0, 2) == 0;
+        }
+    }
+
+    Console.Write("\nPress any key to close...");
+    Stopwatch sw = new Stopwatch();
+    while (!Console.KeyAvailable)
+    {
+        ModifyWorld(world);
+        sw.Restart();
+        PrintWorld(world);
+        sw.Stop();
+        Console.WriteLine("Elapsed time: {0} ms / {1} fps", sw.ElapsedMilliseconds, 1000 / sw.ElapsedMilliseconds);
+        //Task.Delay(500).Wait();
+    }
+}
+
+void PrintWorld(bool[,] bools)
+{
+    for(int i = 0; i<bools.GetLength(0); i++)
+    {
+        for(int j = 0; j<bools.GetLength(1); j++)
+        {
+            Board.SetCellContent(i, j, bools[i, j] ? "X" : " ", Brushes.Black);
+        }
+    }
+}
+
+void ModifyWorld(bool[,] bools)
+{
+    for (int i = 0; i < bools.GetLength(0); i++)
+    {
+        for (int j = 0; j < bools.GetLength(1); j++)
+        {
+            bools[i, j] = Random.Shared.Next(0, 2) == 0;
+        }
+    }
+
+}
+
+void HandleClick(int row, int col, bool leftClick, bool ctrlKeyPressed)
+{
+    string ctrlState = ctrlKeyPressed ? " while pressing the Ctrl key" : string.Empty;
+    Console.WriteLine($"Clicked cell ({row}, {col}) with {(leftClick ? "left" : "right")} mouse button{ctrlState}");
+    if (leftClick)
+    {
+        Board.SetCellContent(row, col, "A", Brushes.Green);
+    }
+    else
+    {
+        Board.SetCellContent(row, col, "B", Brushes.Purple);
+    }
+}


### PR DESCRIPTION
Änderungen nur in LeoBoard/Board.cs relevant; Rest ist mein vermurkstes Fork, in das ich auch mein Testprogramm und das GameOfLive integriert habe.

Problem war, dass der Click-Handler auf dem UI-Thread läuft. Somit wartet der Click-Handler, wenn er SetCellContent aufruft, dass der UI Thread wieder frei wird => deadlock. Daher werden Lock und Post jetzt nur für "fremde Threads" gemacht, und wenn wer schon am UI Thread daher kommt, gibt es ein direktes Invoke.